### PR TITLE
Use Backdrop 1.29.1 release.

### DIFF
--- a/.devpanel/init.sh
+++ b/.devpanel/init.sh
@@ -35,7 +35,7 @@ SETTINGS_FILES_PATH="$WEB_ROOT/settings.local.php"
 # Using zip download of release shows version and date in .info files
 if [[ ! -d "$APP_ROOT/core" ]]; then
   echo "Initial backdrop ..."
-  cd /tmp && wget https://github.com/backdrop/backdrop/releases/download/1.28.2/backdrop.zip
+  cd /tmp && wget https://github.com/backdrop/backdrop/releases/download/1.29.1/backdrop.zip
   cd $APP_ROOT
   unzip /tmp/backdrop.zip && rm -f backdrop.zip && mv -f ./backdrop/{.,}* . ; rm -rf backdrop
 fi


### PR DESCRIPTION
Fixes https://github.com/devpanel-demo/backdrop-cms-quickstart/issues/37